### PR TITLE
Update contact buttons to open email links

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -33,15 +33,15 @@ export default function Footer() {
             <h3 className="font-semibold text-foreground mb-4">Quick Links</h3>
             <ul className="space-y-2.5 text-sm">
               <li>
-                <Link href="/contact">
-                  <div 
-                    className="text-muted-foreground hover:text-primary transition-colors cursor-pointer" 
+                <a href="mailto:support@start341.com">
+                  <div
+                    className="text-muted-foreground hover:text-primary transition-colors cursor-pointer"
                     data-testid="footer-link-contact"
                     onClick={() => trackFooterLink('Contact')}
                   >
                     Contact Us
                   </div>
-                </Link>
+                </a>
               </li>
               <li>
                 <Link href="/privacy-policy">

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -58,7 +58,7 @@ export default function Header() {
             ))}
 
             {/* Contact Us Button */}
-            <Link href="/contact">
+            <a href="mailto:support@start341.com">
               <Button
                 data-testid="button-contact-us"
                 variant="default"
@@ -67,7 +67,7 @@ export default function Header() {
               >
                 Contact Us
               </Button>
-            </Link>
+            </a>
           </div>
 
           {/* Mobile menu button */}
@@ -113,7 +113,7 @@ export default function Header() {
               ))}
 
               {/* Contact */}
-              <Link href="/contact">
+              <a href="mailto:support@start341.com">
                 <div
                   data-testid="link-mobile-contact"
                   className="block py-2.5 px-3 text-base font-medium text-primary hover-elevate rounded-md cursor-pointer"
@@ -121,7 +121,7 @@ export default function Header() {
                 >
                   Contact Us
                 </div>
-              </Link>
+              </a>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- update the header contact buttons to open a support email composer instead of routing to the contact page
- make the footer "Contact Us" link trigger the same support email link

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691775ce5770832980c62b3835c43fb9)