### PR TITLE
Fix premium domain wrapping

### DIFF
--- a/client/src/components/DomainCard.tsx
+++ b/client/src/components/DomainCard.tsx
@@ -18,7 +18,10 @@ export default function DomainCard({ domain }: DomainCardProps) {
         </div>
       )}
       <CardHeader className="pb-3">
-        <h3 className="text-xl font-bold font-display text-foreground leading-tight" data-testid={`text-domain-name-${domain.name}`}>
+        <h3
+          className="text-xl font-bold font-display text-foreground leading-tight break-words"
+          data-testid={`text-domain-name-${domain.name}`}
+        >
           {domain.name}
         </h3>
       </CardHeader>


### PR DESCRIPTION
## Summary
- allow premium domain names to wrap within their cards so the full domain text is always visible on smaller screens

## Testing
- `npm run check`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178277656c8329979af14f1c51b480)