### PR TITLE
Scroll to top when navigating via LinkButton

### DIFF
--- a/client/src/components/LinkButton.tsx
+++ b/client/src/components/LinkButton.tsx
@@ -18,6 +18,11 @@ export default function LinkButton({ href, children, trackLabel, ...props }: Lin
       trackEvent('navigation', 'Button Click', trackLabel);
     }
     setLocation(href);
+
+    // Ensure we land at the top of the destination page
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure LinkButton scrolls the window to the top after routing so Compare buttons land the user at the top of the destination page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919077a3b20832993f4cdf1b3b7cf68)