### PR TITLE
Update footer company attribution

### DIFF
--- a/client/src/config/site.ts
+++ b/client/src/config/site.ts
@@ -8,6 +8,6 @@ export const siteConfig: SiteConfig = {
   email: "support@start341.com",
   googleAnalytics: "G-G33CYW2XXV",
   facebookPixel: "",
-  company: "Start341",
+  company: "Start341.com LLC",
   companyUrl: "https://start341.com",
 };


### PR DESCRIPTION
## Summary
- update the site configuration so the footer now attributes SavingsJoy as a product of Start341.com LLC

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190890d974832987bc57ba395b0194)