### PR TITLE
Remove RentOwnHomeListings.com affiliate link from realestate page

### DIFF
--- a/client/src/config/verticals.ts
+++ b/client/src/config/verticals.ts
@@ -22,19 +22,6 @@ export const verticals: Vertical[] = [
         features: ["Bad credit accepted", "Flexible terms", "Path to ownership"],
       },
       {
-        id: "re-7",
-        companyName: "RentOwnHomeListings.com",
-        logoUrl: "https://logo.clearbit.com/rentownhomelistings.com",
-        title: "RentOwnHomeListings.com - Rent-to-Own & Foreclosure Homes",
-        description:
-          "Find rent-to-own homes, lease options, foreclosures and more. Start putting money towards a home that will be yours!",
-        displayUrl: "rentownhomelistings.com",
-        affiliateLink:
-          "https://afflat3d2.com/trk/lnk/EEE9DFAF-CB8C-4563-90BE-F106EE5F970B/?o=9520&c=918277&a=747832&k=5DF6F6A8ECA69C9B28366F29DF3F216B&l=9052",
-        rating: 4.4,
-        features: ["Rent-to-own homes", "Foreclosure listings", "Lease options"],
-      },
-      {
         id: "re-8",
         companyName: "BuyDistressed.com",
         logoUrl: "https://logo.clearbit.com/buydistressed.com",


### PR DESCRIPTION
## Summary

- Removes the RentOwnHomeListings.com offer (`re-7`) from the real estate vertical
- Eliminates the `afflat3d2.com` affiliate link (`o=9520`) from `savingsjoy.com/realestate`

## Test plan
- [ ] Visit `/realestate` and confirm RentOwnHomeListings.com card no longer appears
- [ ] Verify remaining real estate offers still display correctly

https://claude.ai/code/session_01JmBr3YYzhV21y1zwiXyHUr